### PR TITLE
built app drawer to house settings, such as import/export

### DIFF
--- a/lib/screen/list_view_screen.dart
+++ b/lib/screen/list_view_screen.dart
@@ -4,6 +4,7 @@ import 'package:mobx/mobx.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
 import 'package:dollar_bill_tracker/model/list_item_model.dart';
+import 'package:dollar_bill_tracker/widget/drawer.dart';
 import 'package:dollar_bill_tracker/widget/searchBar.dart';
 import 'package:dollar_bill_tracker/widget/modalTrigger.dart';
 
@@ -45,6 +46,7 @@ class _ListScreenState extends State<ListScreen> {
       appBar: AppBar(
         title: Text('List'),
       ),
+      drawer: SettingsDrawer(),
       body: Observer(
         builder: (_) => ListView.builder(
           itemBuilder: (context, index) {

--- a/lib/widget/drawer.dart
+++ b/lib/widget/drawer.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:dollar_bill_tracker/widget/drawerOptions.dart';
+
+class SettingsDrawer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        children: <Widget>[
+          DrawerHeader(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: <Color>[
+                  Colors.green,
+                  Colors.greenAccent
+                ]
+              )
+            ),
+            child: Container(
+              child: Column(
+                children: <Widget>[
+                  Material(
+                    elevation: 10,
+                    child: Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: Icon(
+                        Icons.settings,
+                        size: 80,
+                        color: Colors.green,
+                      ),
+                    ),
+                    borderRadius: BorderRadius.all(Radius.circular(50)),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: Text(
+                      'Settings',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20.0,
+                      )
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+          DrawerOptions(Icons.restore, 'Import', ()=> {}),
+          DrawerOptions(Icons.backup, 'Export', ()=> {}),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widget/drawerOptions.dart
+++ b/lib/widget/drawerOptions.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class DrawerOptions extends StatelessWidget {
+  IconData icon;
+  String text;
+  Function onTap;
+  DrawerOptions(this.icon, this.text, this.onTap);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      splashColor: Colors.greenAccent,
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(8.0, 0, 8.0, 0),
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(bottom: BorderSide(color: Colors.grey[400]))
+          ),
+          height:  50.0,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0, 0, 8.0, 0),
+                    child: Icon(icon)
+                  ),
+                  Text(text),
+                ],
+              ),
+              Icon(Icons.arrow_right),
+            ],
+          ),
+        ),
+      ),
+      onTap: onTap
+    );
+  }
+
+}


### PR DESCRIPTION
closes #1 

Originally the intent was to build out import/export, however not enough foundational work is done to begin this task (item stores). Feature/Issue was reworked to set the UI ground work for Import/Export by way for a settings drawer.
